### PR TITLE
Fix fail on initilizing modules by duplicating modules address issue

### DIFF
--- a/solanum.go
+++ b/solanum.go
@@ -46,8 +46,8 @@ func (server *runner) SetModules(m ...Module) {
 		server.modules = make([]*Module, 0)
 	}
 
-	for _, module := range m {
-		server.modules = append(server.modules, &module)
+	for i := range m {
+		server.modules = append(server.modules, &m[i])
 	}
 
 }


### PR DESCRIPTION
- #7 
- Module을 여러개 등록할 때 주소 참조 이슈로 인해 제일 마지막 모듈의 Uri를 이용해 모든 모듈의 Router가 등록되는 버그 수정
  - 애초에 실행이 안됨