### PR TITLE
refactor: SolaService 포인터 적용

### DIFF
--- a/docs/examples/dependency_injection/mvc/user/controller.go
+++ b/docs/examples/dependency_injection/mvc/user/controller.go
@@ -9,12 +9,12 @@ func NewController() *solanum.SolaController {
 	ctrl := solanum.NewController()
 
 	ctrl.SetHandlers(
-		solanum.SolaService{
+		&solanum.SolaService{
 			Uri:     "/users",
 			Method:  http.MethodGet,
 			Handler: retrieveUser,
 		},
-		solanum.SolaService{
+		&solanum.SolaService{
 			Uri:     "/users",
 			Method:  http.MethodPost,
 			Handler: addUser,

--- a/hz.controller.go
+++ b/hz.controller.go
@@ -7,11 +7,13 @@ import (
 func NewHealthCheckController() *SolaController {
 	healthCheckController := NewController()
 
-	healthCheckController.SetHandlers(SolaService{
-		Uri:     "",
-		Method:  http.MethodGet,
-		Handler: hzHandler,
-	})
+	healthCheckController.SetHandlers(
+		&SolaService{
+			Uri:     "",
+			Method:  http.MethodGet,
+			Handler: hzHandler,
+		},
+	)
 
 	return healthCheckController
 }

--- a/solanum.interface.go
+++ b/solanum.interface.go
@@ -20,10 +20,10 @@ type (
 	// Controller declares a set of service handlers for a logical grouping of routes.
 	Controller interface {
 		// Handlers returns the slice of service definitions this controller manages.
-		Handlers() []SolaService
+		Handlers() []*SolaService
 
 		// SetHandlers adds one or more SolaService entries to the controller.
-		SetHandlers(handler ...SolaService)
+		SetHandlers(handler ...*SolaService)
 	}
 
 	// Module represents a self-contained HTTP module with its own URI prefix,

--- a/solanum.struct.go
+++ b/solanum.struct.go
@@ -20,7 +20,7 @@ type (
 	// SolaController groups one or more SolaService handlers under a logical controller.
 	// It implements the Controller interface, managing a list of SolaService entries.
 	SolaController struct {
-		handlers []SolaService // handlers service handlers defined for this controller
+		handlers []*SolaService // handlers service handlers defined for this controller
 	}
 
 	// SolaService represents a single HTTP route handler configuration.
@@ -169,14 +169,14 @@ func (m *SolaModule) Uri() string {
 // NewController constructs an empty SolaController ready to receive handlers.
 func NewController() *SolaController {
 	return &SolaController{
-		handlers: nil,
+		handlers: make([]*SolaService, 0),
 	}
 }
 
 // SetHandlers appends one or more SolaService entries to the controller's handler list.
-func (ctr *SolaController) SetHandlers(handlers ...SolaService) {
+func (ctr *SolaController) SetHandlers(handlers ...*SolaService) {
 	if ctr.handlers == nil {
-		ctr.handlers = make([]SolaService, 0)
+		ctr.handlers = make([]*SolaService, 0)
 	}
 
 	// ctr.handlers = append(ctr.handlers, *svc)
@@ -184,6 +184,6 @@ func (ctr *SolaController) SetHandlers(handlers ...SolaService) {
 }
 
 // Handlers returns the slice of SolaService entries managed by this controller.
-func (ctr *SolaController) Handlers() []SolaService {
+func (ctr *SolaController) Handlers() []*SolaService {
 	return ctr.handlers
 }


### PR DESCRIPTION
## 🚀 리팩토링

### 설명
`SolaService`에 포인터를 적용합니다.

1. solanum.interface.go: Controller에 할당되는 `SolaService`를 포인터로 변경합니다.
2. solanum.struct.go: (1)의 변경에 따라 내용을 수정합니다.
3. healthcheck 모듈과 예제 파일을 수정합니다.