### PR TITLE
feat: WithDep 기능 추가

### DIFF
--- a/container.go
+++ b/container.go
@@ -2,7 +2,6 @@ package solanum
 
 import (
 	"fmt"
-	"log"
 	"reflect"
 	"sync"
 )
@@ -123,8 +122,6 @@ func Register(key string, provider interface{}, opts ...RegisterOption) {
 			})
 		}
 	}
-
-	log.Printf("deps :: %v\n", deps)
 
 	// If provider is a function, wrap it to perform nested dependency resolution
 	if pt.Kind() == reflect.Func {

--- a/docs/examples/dependency_injection/mvc/dependencies.go
+++ b/docs/examples/dependency_injection/mvc/dependencies.go
@@ -9,8 +9,10 @@ import (
 )
 
 func RegisterDependencies() {
+
+	// Register a singleton database connection
 	solanum.Register("db", func() *sql.DB {
-		dsn := "postgres://postgres:postgres@localhost:5432/annuums?sslmode=disable"
+		dsn := "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 		db, err := sql.Open("postgres", dsn)
 		if err != nil {
 			panic(fmt.Errorf("db open: %w", err))
@@ -18,7 +20,14 @@ func RegisterDependencies() {
 		return db
 	}, solanum.WithSingleton())
 
-	solanum.Register("userRepository", func(db *sql.DB) user.UserRepository {
-		return &user.UserRepoImpl{DB: db}
-	}, solanum.WithTransient(), solanum.As((*user.UserRepository)(nil)))
+	// Register a transient user repository
+	solanum.Register(
+		"userRepository",
+		func(db *sql.DB) user.UserRepository {
+			return &user.UserRepoImpl{DB: db}
+		},
+		solanum.WithTransient(),
+		solanum.As((*user.UserRepository)(nil)),
+		solanum.WithDep[*sql.DB]("db"), // Declare *sql.DB dependency to find it in the container with key "db"
+	)
 }

--- a/solanum.struct.go
+++ b/solanum.struct.go
@@ -3,7 +3,6 @@ package solanum
 import (
 	"fmt"
 	"github.com/gin-gonic/gin"
-	"log"
 )
 
 type (
@@ -136,7 +135,7 @@ func diMiddleware(deps []DependencyConfig) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		seen := make(map[string]struct{}, len(deps))
 		for _, d := range deps {
-			log.Printf("key :: %v, interface :: %v", d.Key, d.Type)
+
 			if _, dup := seen[d.Key]; dup {
 				panic(fmt.Sprintf("duplicate dependency key: %q", d.Key))
 			}


### PR DESCRIPTION
This pull request enhances the dependency injection (DI) system in the `solanum` package by introducing dependency configuration, improving provider registration, and refining dependency resolution. It also updates an example to demonstrate the new functionality.

### Enhancements to Dependency Injection:

* **Dependency Configuration Added to Providers**: Introduced a `deps` field in the `providerEntry` struct to store dependencies, and added a new `WithDep` option to specify dependencies during registration. (`container.go`, [[1]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaR34-R36) [[2]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaR73-R87)
* **Improved Dependency Resolution**: Updated the `Register` function to infer and resolve dependencies dynamically, supporting both key-based and type-based resolution. (`container.go`, [container.goR102-R182](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaR102-R182))

### Example Updates:

* **Updated Dependency Registration**: Modified the `RegisterDependencies` function in the example to use the new `WithDep` option, explicitly declaring dependencies like `*sql.DB` for the `userRepository`. (`docs/examples/dependency_injection/mvc/dependencies.go`, [docs/examples/dependency_injection/mvc/dependencies.goR12-R32](diffhunk://#diff-12ce3692bef38c9e071c75a6066a26a499355236af8d28e7a40d750fcb99d9c0R12-R32))

### Codebase Refinements:

* **Factory Function Signature Updated**: Changed the `factory` field in `providerEntry` to accept variadic arguments, enabling more flexible dependency injection. (`container.go`, [container.goL14-R15](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL14-R15))
* **Logging Adjustments**: Added and removed logging statements for debugging dependency resolution and middleware behavior. (`container.go`, [[1]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaR102-R182); `solanum.struct.go`, [[2]](diffhunk://#diff-31522d84e6e9256e163474563a75f701b3c10de3c7cbaedfe2c5d613cbc127c6L139-R138); [[3]](diffhunk://#diff-31522d84e6e9256e163474563a75f701b3c10de3c7cbaedfe2c5d613cbc127c6L6)

These changes improve the flexibility and usability of the DI system while maintaining backward compatibility.