### PR TITLE
feat: SolaService에 대한 pre, post handler 추가

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -22,9 +22,9 @@ type SolaService struct {
 	// Handler is the Gin handler function to execute.
 	Handler gin.HandlerFunc
 
-	// PostHandlers are middleware functions intended to run later in this route's Gin
-	// handler chain. They execute only if Handler, or a wrapper around it, calls
-	// ctx.Next().
+	// PostHandlers are middleware functions to run after Handler for this route only.
+	// Gin executes all handlers in the chain sequentially; ctx.Next() is not required.
+	// Use ctx.Abort() in any handler to stop further execution.
 	PostHandlers []gin.HandlerFunc
 }
 

--- a/controller.go
+++ b/controller.go
@@ -16,8 +16,14 @@ type SolaService struct {
 	// Method is the HTTP method to bind (GET, POST, etc.).
 	Method string
 
+	// PreHandlers are middleware functions to run before Handler for this route only.
+	PreHandlers []gin.HandlerFunc
+
 	// Handler is the Gin handler function to execute.
 	Handler gin.HandlerFunc
+
+	// PostHandlers are middleware functions to run after Handler for this route only.
+	PostHandlers []gin.HandlerFunc
 }
 
 // NewController constructs an empty SolaController ready to receive handlers.

--- a/controller.go
+++ b/controller.go
@@ -22,7 +22,9 @@ type SolaService struct {
 	// Handler is the Gin handler function to execute.
 	Handler gin.HandlerFunc
 
-	// PostHandlers are middleware functions to run after Handler for this route only.
+	// PostHandlers are middleware functions intended to run later in this route's Gin
+	// handler chain. They execute only if Handler, or a wrapper around it, calls
+	// ctx.Next().
 	PostHandlers []gin.HandlerFunc
 }
 

--- a/module.go
+++ b/module.go
@@ -108,9 +108,11 @@ func (m *SolaModule) SetRoutes(router *gin.RouterGroup) {
 	for _, c := range m.controllers {
 		for _, svc := range c.Handlers() {
 
-			chain := make([]gin.HandlerFunc, 0, len(m.preMiddlewares)+1+len(m.postMiddlewares))
+			chain := make([]gin.HandlerFunc, 0, len(m.preMiddlewares)+len(svc.PreHandlers)+1+len(svc.PostHandlers)+len(m.postMiddlewares))
 			chain = append(chain, m.preMiddlewares...)
+			chain = append(chain, svc.PreHandlers...)
 			chain = append(chain, svc.Handler)
+			chain = append(chain, svc.PostHandlers...)
 			chain = append(chain, m.postMiddlewares...)
 			router.Handle(svc.Method, svc.Uri, chain...)
 		}

--- a/module.go
+++ b/module.go
@@ -102,7 +102,7 @@ func (m *SolaModule) AddControllers(c ...Controller) {
 }
 
 // SetRoutes registers the module's routes and middleware on the given RouterGroup.
-// The final handler chain per route is: pre-middlewares → handler → post-middlewares.
+// The final handler chain per route is: module pre-middlewares → service PreHandlers → handler → service PostHandlers → module post-middlewares.
 func (m *SolaModule) SetRoutes(router *gin.RouterGroup) {
 
 	for _, c := range m.controllers {

--- a/solanum_module_test.go
+++ b/solanum_module_test.go
@@ -41,6 +41,69 @@ func TestMiddlewareChains(t *testing.T) {
 	assert.Len(t, m.PostMiddlewares(), 2)
 }
 
+// TestServiceHandlerExecutionOrder asserts the full middleware execution order:
+// module pre → service pre → handler → service post → module post.
+func TestServiceHandlerExecutionOrder(t *testing.T) {
+
+	var order []string
+	r := gin.New()
+
+	m := solanum.NewModule(solanum.WithUri("/api"))
+	m.SetPreMiddlewares(func(c *gin.Context) { order = append(order, "module-pre") })
+	m.SetPostMiddlewares(func(c *gin.Context) { order = append(order, "module-post") })
+
+	ctrl := solanum.NewController()
+	ctrl.SetHandlers(&solanum.SolaService{
+		Uri:    "/order",
+		Method: http.MethodGet,
+		PreHandlers: []gin.HandlerFunc{
+			func(c *gin.Context) { order = append(order, "service-pre") },
+		},
+		Handler: func(c *gin.Context) {
+			order = append(order, "handler")
+			c.String(http.StatusOK, "ok")
+		},
+		PostHandlers: []gin.HandlerFunc{
+			func(c *gin.Context) { order = append(order, "service-post") },
+		},
+	})
+	m.AddControllers(ctrl)
+	m.SetRoutes(r.Group("/api"))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/order", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"module-pre", "service-pre", "handler", "service-post", "module-post"}, order)
+}
+
+// TestServiceHandlerNilPrePostHandlers ensures a SolaService with no PreHandlers/PostHandlers
+// behaves identically to the original single-handler registration.
+func TestServiceHandlerNilPrePostHandlers(t *testing.T) {
+
+	r := gin.New()
+
+	m := solanum.NewModule(solanum.WithUri("/api"))
+	ctrl := solanum.NewController()
+	ctrl.SetHandlers(&solanum.SolaService{
+		Uri:    "/nil",
+		Method: http.MethodGet,
+		Handler: func(c *gin.Context) {
+			c.String(http.StatusOK, "ok")
+		},
+	})
+	m.AddControllers(ctrl)
+	m.SetRoutes(r.Group("/api"))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/nil", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", rec.Body.String())
+}
+
 // TestSetRoutes ensures routes are correctly registered and respond to requests.
 func TestSetRoutes(t *testing.T) {
 	r := gin.New()


### PR DESCRIPTION
- SolaService에 대한 Pre, Post Handler를 추가하여 조금 더 유연한 http 처리를 지원합니다.
  - module.PreMiddlewares → svc.PreHandlers → svc.Handler → svc.PostHandlers → module.PostMiddlewares
